### PR TITLE
adding menuconfig options for defining Task to core affinity as well as task priority

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -101,6 +101,62 @@ menu "esp32_BNO08x"
                 Stack size of task responsible for calling shtp_service() when HINT is asserted,
                 to dispatch any sh2 HAL lib callbacks.
 
+        config ESP32_BNO08X_CB_TASK_AFFINITY
+            int "Callback task core affinity"
+            range -1 1
+            default -1
+            help
+            Core to which the callback task is pinned.
+            -1 = No specific core (tskNO_AFFINITY)
+            0 = Core 0
+            1 = Core 1
+
+        config ESP32_BNO08X_CB_TASK_PRIORITY
+            int "Callback task priority"
+            range 0 25
+            default 5
+            help
+            Priority of the callback task.
+            0 is lowest priority, 25 is highest priority.
+
+        config ESP32_BNO08X_DATA_PROC_TASK_AFFINITY
+            int "Data processing task core affinity"
+            range -1 1
+            default -1
+            help
+            Core to which the data processing task is pinned.
+            -1 = No specific core (tskNO_AFFINITY)
+            0 = Core 0
+            1 = Core 1
+
+        config ESP32_BNO08X_DATA_PROC_TASK_PRIORITY
+            int "Data processing task priority"
+            range 0 25
+            default 6
+            help
+            Priority of the data processing task.
+            0 is lowest priority, 25 is highest priority.
+
+        config ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY
+            int "SH2 HAL service task core affinity"
+            range -1 1
+            default -1
+            help
+            Core to which the SH2 HAL service task is pinned.
+            -1 = No specific core (tskNO_AFFINITY)
+            0 = Core 0
+            1 = Core 1
+
+        config ESP32_BNO08X_SH2_HAL_SERVICE_TASK_PRIORITY
+            int "SH2 HAL service task priority"
+            range 0 25
+            default 7
+            help
+            Priority of the SH2 HAL service task.
+            0 is lowest priority, 25 is highest priority.
+
+
+
     endmenu #Tasks
 
     menu "Callbacks"

--- a/include/BNO08x.hpp
+++ b/include/BNO08x.hpp
@@ -150,6 +150,22 @@ class BNO08x
         static void cb_task_trampoline(void* arg);
         void cb_task();
 
+
+        //------------ addition flyinggorilla -----------
+        static const constexpr BaseType_t CB_TASK_AFFINITY = 
+                CONFIG_ESP32_BNO08X_CB_TASK_AFFINITY < 1 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_CB_TASK_AFFINITY ;  /// tskNO_AFFINITY if not pinned to a core, 0 or 1
+        static const constexpr UBaseType_t CB_TASK_PRIORITY = CONFIG_ESP32_BNO08X_CB_TASK_PRIORITY; /// 5 per default, Priority of the callback task, 0-25, 0 is lowest priority, 25 is highest priority
+
+        static const constexpr BaseType_t DATA_PROC_TASK_AFFINITY = 
+                CONFIG_ESP32_BNO08X_DATA_PROC_TASK_AFFINITY < 1 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_DATA_PROC_TASK_AFFINITY; /// tskNO_AFFINITY if not pinned to a core, 0 or 1
+        static const constexpr UBaseType_t DATA_PROC_TASK_PRIORITY = CONFIG_ESP32_BNO08X_DATA_PROC_TASK_PRIORITY; /// 6 per default, Priority of the data processing task, 0-25, 0 is lowest priority, 25 is highest priority
+        
+        static const constexpr BaseType_t SH2_HAL_SERVICE_TASK_AFFINITY = 
+                CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY < 1 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY; /// tskNO_AFFINITY if not pinned to a core, 0 or 1
+        static const constexpr UBaseType_t SH2_HAL_SERVICE_TASK_PRIORITY = CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_PRIORITY; /// 7 per default, Priority of the sh2 HAL service task, 0-25, 0 is lowest priority, 25 is highest priority
+        //-----------------------------------------------
+
+
         SemaphoreHandle_t sem_kill_tasks; ///<Counting Semaphore to count amount of killed tasks.
 
         void lock_sh2_HAL();

--- a/include/BNO08x.hpp
+++ b/include/BNO08x.hpp
@@ -150,20 +150,17 @@ class BNO08x
         static void cb_task_trampoline(void* arg);
         void cb_task();
 
-
-        //------------ addition flyinggorilla -----------
         static const constexpr BaseType_t CB_TASK_AFFINITY = 
-                CONFIG_ESP32_BNO08X_CB_TASK_AFFINITY < 1 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_CB_TASK_AFFINITY ;  /// tskNO_AFFINITY if not pinned to a core, 0 or 1
+                CONFIG_ESP32_BNO08X_CB_TASK_AFFINITY < 0 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_CB_TASK_AFFINITY ;  /// tskNO_AFFINITY if not pinned to a core, 0 or 1
         static const constexpr UBaseType_t CB_TASK_PRIORITY = CONFIG_ESP32_BNO08X_CB_TASK_PRIORITY; /// 5 per default, Priority of the callback task, 0-25, 0 is lowest priority, 25 is highest priority
 
         static const constexpr BaseType_t DATA_PROC_TASK_AFFINITY = 
-                CONFIG_ESP32_BNO08X_DATA_PROC_TASK_AFFINITY < 1 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_DATA_PROC_TASK_AFFINITY; /// tskNO_AFFINITY if not pinned to a core, 0 or 1
+                CONFIG_ESP32_BNO08X_DATA_PROC_TASK_AFFINITY < 0 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_DATA_PROC_TASK_AFFINITY; /// tskNO_AFFINITY if not pinned to a core, 0 or 1
         static const constexpr UBaseType_t DATA_PROC_TASK_PRIORITY = CONFIG_ESP32_BNO08X_DATA_PROC_TASK_PRIORITY; /// 6 per default, Priority of the data processing task, 0-25, 0 is lowest priority, 25 is highest priority
         
         static const constexpr BaseType_t SH2_HAL_SERVICE_TASK_AFFINITY = 
-                CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY < 1 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY; /// tskNO_AFFINITY if not pinned to a core, 0 or 1
+                CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY < 0 ? tskNO_AFFINITY : CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_AFFINITY; /// tskNO_AFFINITY if not pinned to a core, 0 or 1
         static const constexpr UBaseType_t SH2_HAL_SERVICE_TASK_PRIORITY = CONFIG_ESP32_BNO08X_SH2_HAL_SERVICE_TASK_PRIORITY; /// 7 per default, Priority of the sh2 HAL service task, 0-25, 0 is lowest priority, 25 is highest priority
-        //-----------------------------------------------
 
 
         SemaphoreHandle_t sem_kill_tasks; ///<Counting Semaphore to count amount of killed tasks.

--- a/source/BNO08x.cpp
+++ b/source/BNO08x.cpp
@@ -668,8 +668,6 @@ esp_err_t BNO08x::init_tasks()
         &cb_task_hdl, 
         CB_TASK_AFFINITY);
 
-    ESP_LOGW(TAG, "cb_task affinity: %d", CB_TASK_AFFINITY);
-
     if (task_created != pdTRUE)
     {
         // clang-format off

--- a/source/BNO08x.cpp
+++ b/source/BNO08x.cpp
@@ -636,9 +636,14 @@ esp_err_t BNO08x::init_tasks()
 
     xEventGroupSetBits(sync_ctx.evt_grp_task, EVT_GRP_BNO08x_TASKS_RUNNING);
 
-    // launch data processing task
-    task_created = xTaskCreate(
-            &data_proc_task_trampoline, "bno08x_data_processing_task", DATA_PROC_TASK_SZ, this, 6, &data_proc_task_hdl);
+    // launch data processing task 6
+    task_created = xTaskCreatePinnedToCore(
+            &data_proc_task_trampoline, "bno08x_data_processing_task", 
+            DATA_PROC_TASK_SZ, 
+            this, 
+            DATA_PROC_TASK_PRIORITY, 
+            &data_proc_task_hdl, 
+            DATA_PROC_TASK_AFFINITY);
 
     if (task_created != pdTRUE)
     {
@@ -655,8 +660,15 @@ esp_err_t BNO08x::init_tasks()
         init_status.data_proc_task = true;
     }
 
-    // launch cb task
-    task_created = xTaskCreate(&cb_task_trampoline, "bno08x_cb_task", CB_TASK_SZ, this, 5, &cb_task_hdl);
+    // launch cb task 5
+    task_created = xTaskCreatePinnedToCore(&cb_task_trampoline, "bno08x_cb_task", 
+        CB_TASK_SZ, 
+        this, 
+        CB_TASK_PRIORITY, 
+        &cb_task_hdl, 
+        CB_TASK_AFFINITY);
+
+    ESP_LOGW(TAG, "cb_task affinity: %d", CB_TASK_AFFINITY);
 
     if (task_created != pdTRUE)
     {
@@ -673,9 +685,13 @@ esp_err_t BNO08x::init_tasks()
         init_status.cb_task = true;
     }
 
-    // launch sh2 hal service task
-    task_created = xTaskCreate(&sh2_HAL_service_task_trampoline, "bno08x_sh2_HAL_service_task", SH2_HAL_SERVICE_TASK_SZ, this, 7,
-            &sh2_HAL_service_task_hdl);
+    // launch sh2 hal service task 7
+    task_created = xTaskCreatePinnedToCore(&sh2_HAL_service_task_trampoline, "bno08x_sh2_HAL_service_task", 
+        SH2_HAL_SERVICE_TASK_SZ, 
+        this, 
+        SH2_HAL_SERVICE_TASK_PRIORITY,
+        &sh2_HAL_service_task_hdl,
+        SH2_HAL_SERVICE_TASK_AFFINITY);
 
     if (task_created != pdTRUE)
     {


### PR DESCRIPTION
defaults for no-core-affinity and task priorities are same behavior as before, but it is now possible to override defaults in menuconfig or sdkconfig.defaults for task core affinity and priority.
thanks for considering adding these advanced config options. i do need them in my project, to reduce likelyhood of queues running full.