### PR TITLE
fixed checking for min 4 dwords in get_system_orientation

### DIFF
--- a/source/BNO08x.cpp
+++ b/source/BNO08x.cpp
@@ -2039,7 +2039,7 @@ bool BNO08x::get_system_orientation(float& Qw, float& Qx, float& Qy, float& Qz)
     if(!get_frs(BNO08xFrsID::SYSTEM_ORIENTATION, raw, words_rxd))
         return false;
     
-    if(words_rxd <= 4U)
+    if(words_rxd < 4U)
     {
         // clang-format off
         #ifdef CONFIG_ESP32_BNO08x_LOG_STATEMENTS


### PR DESCRIPTION
thanks a lot for merging new functionality cleanly into your library.
there was a minor comparison error that let get_system_orientation fail despite 4 dwords returned correctly. 
with that fix the updated library works now great!

thanks a lot,
flyinggorilla

before:
![image](https://github.com/user-attachments/assets/36eece09-d8b2-4b55-a474-4819333ca42c)

after:
![image](https://github.com/user-attachments/assets/ada9138c-0c4c-4228-946c-23ce8e1cccd0)

