### PR TITLE
Fix invalid data writing in set_system_orientation function

### DIFF
--- a/source/BNO08x.cpp
+++ b/source/BNO08x.cpp
@@ -2017,7 +2017,7 @@ bool BNO08x::set_system_orientation(float Qw, float Qx, float Qy, float Qz)
         static_cast<uint32_t>(float_to_q30(Qw))  // W component
     };
 
-    if(!write_frs(BNO08xFrsID::SYSTEM_ORIENTATION, orientation_raw, sizeof(orientation_raw)))
+    if(!write_frs(BNO08xFrsID::SYSTEM_ORIENTATION, orientation_raw, sizeof(orientation_raw)/sizeof(uint32_t)))
         return false; 
 
     return true;


### PR DESCRIPTION
Correct the calculation of the size parameter in the write_frs function call to ensure valid data is written for system orientation.